### PR TITLE
Update email input with pattern to block popular free email services

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -228,23 +228,23 @@
 					</div>
 					<div>
 						<label for="input-name" class="block">Full name</label>
-						<input class="w-full rounded-md placeholder:text-space-blue-200 text-space-blue-500" type="text" name="name" id="input-name" placeholder="Your Name" required/>
+						<input class="w-full rounded-md placeholder:text-space-blue-200 text-space-blue-500" type="text" name="name" id="input-name" placeholder="Your Name" required>
 					</div>
 					<div>
 						<label for="input-email" class="block">Work Email</label>
-						<input pattern="^[^@]+@(?!gmail|hotmail|yahoo|aol)[^\.]+(?:\.[^\.]+){1,3}$" class="w-full rounded-md placeholder:text-space-blue-200 text-space-blue-500 invalid:text-red-800" type="email" name="email" id="input-email" placeholder="yourname@yourcompany.com" required/>
+						<input pattern="^[^@]+@(?!gmail|hotmail|yahoo|aol)[^\.]+(?:\.[^\.]+){1,3}$" class="w-full rounded-md placeholder:text-space-blue-200 text-space-blue-500 invalid:text-red-800" type="email" name="email" id="input-email" placeholder="yourname@yourcompany.com" required>
 					</div>
 					<div>
 						<label for="input-phone" class="block">Phone</label>
-						<input class="w-full rounded-md placeholder:text-space-blue-200 text-space-blue-500" type="tel" name="phone" id="input-phone" placeholder="+0 (000) 000-0000"/>
+						<input class="w-full rounded-md placeholder:text-space-blue-200 text-space-blue-500" type="tel" name="phone" id="input-phone" placeholder="+0 (000) 000-0000" required>
 					</div>
 					<div>
 						<label for="input-company" class="block">Company Name</label>
-						<input class="w-full rounded-md placeholder:text-space-blue-200 text-space-blue-500" type="text" name="company" id="input-company" placeholder="Company Name"/>
+						<input class="w-full rounded-md placeholder:text-space-blue-200 text-space-blue-500" type="text" name="company" id="input-company" placeholder="Company Name" required>
 					</div>
 					<div>
 						<label for="input-services" class="block">Desired Services</label>
-						<input class="w-full rounded-md placeholder:text-space-blue-200 text-space-blue-500" type="text" name="services" list="service-suggestions" id="input-services" placeholder="See suggestions or add your own"/>
+						<input class="w-full rounded-md placeholder:text-space-blue-200 text-space-blue-500" type="text" name="services" list="service-suggestions" id="input-services" placeholder="See suggestions or add your own" required>
 						<datalist id="service-suggestions">
 							<option value="Consulting">
 							<option value="Content Marketing">


### PR DESCRIPTION
### Related Issues
- Our contact form is being overused by service providers with gmail addresses whose messages are irrelevant.
- Our first idea for fixing this is blocking gmail addresses using a regex pattern on the front-end.

### What Was Accomplished
- Added a pattern to the email input that disallows the words gmail, yahoo, aol or hotmail right after the `@`
- Updated the placeholder for this input to match the intended new pattern which would include your company's domain name rather than a free email service.