### PR TITLE
Remove phone number in contact form

### DIFF
--- a/src/assets/css/index.css
+++ b/src/assets/css/index.css
@@ -7,8 +7,10 @@
 @tailwind utilities;
 
 @layer base {
-	html {
-		scroll-behavior: smooth;
+	@media(prefers-reduced-motion:no-preference) {
+		html {
+			scroll-behavior: smooth;
+		}
 	}
 }
 
@@ -63,11 +65,13 @@
 
 input[type="text"],
 input[type="email"],
-input[type="tel"] {
+input[type="tel"],
+textarea {
 	@apply border-space-blue-500;
 }
 
-input:placeholder-shown {
+input:placeholder-shown,
+textarea:placeholder-shown {
 	@apply border-space-blue-200;
 }
 

--- a/src/index.html
+++ b/src/index.html
@@ -232,7 +232,6 @@
 				<path d="M0,116.05c13.68,0,23.36,7.76,26.24,18.4h.32V0h3.68V134.45h.32c2.88-10.64,12.56-18.4,26.24-18.4v3.76c-13.44,0-21.92,7.92-27.28,21.44H27.28C21.92,127.73,13.44,119.81,0,119.81Z"/>
 			</svg>
 			<h2 class="text-3xl text-center font-serif font-light">Contact us</h2>
-			<p class="text-base max-w-27 mx-auto px-4 text-center font-medium">Say hello and we’ll create a custom proposal for you.</p>
 			<form class="mt-8" name="Agency_Contact" method="POST" data-netlify="true" netlify-honeypot="input-non-human">
 				<fieldset class="space-y-4 px-4 max-w-[35ch] mx-auto">
 					<div class="hidden">
@@ -241,16 +240,12 @@
 						</label>
 					</div>
 					<div>
-						<label for="input-name" class="block">Full name</label>
+						<label for="input-name" class="block">Full Name</label>
 						<input class="w-full rounded-md placeholder:text-space-blue-200 text-space-blue-500" type="text" name="name" id="input-name" placeholder="Your Name" required>
 					</div>
 					<div>
 						<label for="input-email" class="block">Work Email</label>
 						<input pattern="^[^@]+@(?!gmail|hotmail|yahoo|aol)[^\.]+(?:\.[^\.]+){1,3}$" class="w-full rounded-md placeholder:text-space-blue-200 text-space-blue-500 invalid:text-red-800" type="email" name="email" id="input-email" placeholder="yourname@yourcompany.com" required>
-					</div>
-					<div>
-						<label for="input-phone" class="block">Phone</label>
-						<input class="w-full rounded-md placeholder:text-space-blue-200 text-space-blue-500" type="tel" name="phone" id="input-phone" placeholder="+0 (000) 000-0000" required>
 					</div>
 					<div>
 						<label for="input-company" class="block">Company Name</label>


### PR DESCRIPTION
### Related Issues
- Our sales team expects more people will fill out the contact form if we reduce the number of fields.

### What Was Accomplished
- Removed phone number from contact form
- Remove preamble text before contact form
- Updated textarea border styles to match other form inputs
- Updated scroll-behavior to be normal for users who prefer reduced motion